### PR TITLE
Remove the messages sic-sp-name and sic-sp-title

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,8 +30,6 @@
 	"sic-input-commenttext": "Reply",
 	"sic-date-justnow": "just now",
 	"sic-sp-no-access": "You have no access to this page.",
-	"sic-sp-name": "SmartComments",
-	"sic-sp-title": "SmartComments",
 	"sic-sp-tab-overview": "Overview",
 	"sic-sp-tab-help": "Manual",
 	"sic-sp-filter-author": "Filter on author",


### PR DESCRIPTION
These messages appear to be unused. See issue #1.

If I'm wrong and these messages are used,
feel free to close this, but note that their
usage should be properly documented.