### PR TITLE
SmartComments 1.5.1

### DIFF
--- a/ReleaseNotes.wiki
+++ b/ReleaseNotes.wiki
@@ -1,3 +1,7 @@
+; Version 1.5.1 (Jun 25, 2024)
+* Fix missing i18n-strings
+* Replace deprecated "SMWStore::updateDataBefore" hook by "SMW::SQLStore::BeforeDataUpdateComplete"
+
 ; Version 1.5.0 (May 31, 2024)
 * Allow comments to be made on HTML selections
 

--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,7 @@
 		"Robin van der Wiel",
 		"Yvar Nanlohij"
 	],
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"url": "https://www.archixl.nl",
 	"descriptionmsg": "sic-desc",
 	"license-name": "GPL-2.0+",
@@ -37,8 +37,7 @@
 		"SkinTemplateNavigation::Universal": "MediaWiki\\Extension\\SmartComments\\Hooks::onSkinTemplateNavigation",
 		"ResourceLoaderGetConfigVars": "MediaWiki\\Extension\\SmartComments\\Hooks::onResourceLoaderGetConfigVars",
 		"SMW::Property::initProperties": "MediaWiki\\Extension\\SmartComments\\SMWHandler::initProperties",
-		"BeforeDataUpdateComplete": "MediaWiki\\Extension\\SmartComments\\Hooks::addSubobjectsForComments",
-		"SMWStore::updateDataBefore": "MediaWiki\\Extension\\SmartComments\\Hooks::addSubobjectsForComments",
+		"SMW::SQLStore::BeforeDataUpdateComplete": "MediaWiki\\Extension\\SmartComments\\Hooks::addSubobjectsForComments",
 		"ParserCacheSaveComplete": "MediaWiki\\Extension\\SmartComments\\Hooks::onParserCacheSaveComplete",
 		"MediaWikiServices": "MediaWiki\\Extension\\SmartComments\\Hooks::onMediaWikiServices",
 		"PageHistoryPager::getQueryInfo": "MediaWiki\\Extension\\SmartComments\\Hooks::onPageHistoryPagerGetQueryInfo",


### PR DESCRIPTION
### Changes

- Patch version bump to 1.5.1
- Updated ReleaseNotes.wiki
- Remove deprecated hook "SMWStore::updateDataBefore" and replace it with "SMW::SQLStore::BeforeDataUpdateComplete"